### PR TITLE
Read .resource files as .robot files in GitHub

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,4 @@
 # don't add CR to bash scripts
 *.sh text eol=lf
+# consider .resource as .robot
+*.resource linguist-language=RobotFramework


### PR DESCRIPTION
Adding this line to .gitattributes will tell GitHub to format '.resource' files as '.robot' files, making them easier to read