### PR TITLE
delete the docker image after a run

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,8 +13,8 @@ gui:
 	docker-compose -f docker/test.yaml stop && \
 	docker-compose -f docker/hub.yaml stop && \
 	docker-compose -f docker/$(BROWSER).yaml down && \
-	docker rm -f $$(docker ps -a -q)
-# TODO : docker prune?
+	docker rm -f $$(docker ps -a -q) && \
+	docker rmi docker_automation:latest
 
 api:
 	export FILTER=$(FILTER) && \


### PR DESCRIPTION
Since the image of the project is built again in each run, I added a line to delete it after each run.