### PR TITLE
Save pipeline reports in separate folders (run nº-run attempt)

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -2,7 +2,9 @@ name: RF code-check & tests
 
 on:
   schedule:
+    - cron: '0 2 * * *'
     - cron: '0 4 * * *'
+    - cron: '0 6 * * *'
   workflow_dispatch:
   pull_request:
     branches:
@@ -76,3 +78,5 @@ jobs:
         PERSONAL_TOKEN: ${{ secrets.MY_TOKEN }}
         PUBLISH_BRANCH: gh-pages
         PUBLISH_DIR: reports
+        destination_dir: ${{ github.run_number }}-${{ github.run_attempt}}
+        keep_files: true


### PR DESCRIPTION
- Added 2 more scheduled runs
- Set the pipeline to not overwrite the files in the "gh-pages" branch
- each new run attempt will create a new folder inside the branch with the format `(run)-(attempt)` (I didn't include a timestamp for now because a timestamp is shown when browsing the branch through GitHub)